### PR TITLE
Overwrite swagger middleware status code

### DIFF
--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -45,6 +45,7 @@ test('if mocked, with body, returns the mocked status and body', async () => {
     { method: 'PUT', body: JSON.stringify(mock), headers: { 'content-type': 'application/json' } },
   );
   expect(response.status).toEqual(204);
+  expect(response.statusText).toEqual('No Content');
 
   response = await fetch(`${apiBase}/batman/location`, { method: 'GET' });
   expect(response.status).toEqual(mock.status);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parrot",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parrot",
   "repository": "github:mustafar/parrot",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "api mocks",
   "main": "index.js",
   "scripts": {

--- a/publish.sh
+++ b/publish.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -o errexit
 
+if [ $(git rev-parse --abbrev-ref HEAD) != "master" ]; then
+  echo "this script runs only against master"
+  exit 1
+fi
+
 docker_image_name='mustafar/parrot'
 
 if [ -z $1 ]; then


### PR DESCRIPTION
`res.send(204).send('No Content').end()` does not appear to overwrite the status code set by swagger middleware. This fixes that issue