### PR TITLE
chore: remove husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "eslint": "^8.16.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.26.0",
-        "husky": "^8.0.1",
         "jest": "^28.1.0",
         "node-fetch": "^2.0.0"
       },
@@ -5372,21 +5371,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
-      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -13802,12 +13786,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true
-    },
-    "husky": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
-      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "lint": "eslint *.js --cache",
     "test:setup": "bash __tests__/setup.sh",
     "test": "jest",
-    "docker:stop": "docker stop $(docker ps -a -q --filter=\"ancestor=mustafar/parrot\") 2>/dev/null && docker rm $(docker ps -a -q --filter=\"ancestor=mustafar/parrot\") 2>/dev/null",
-    "prepare": "husky install"
+    "docker:stop": "docker stop $(docker ps -a -q --filter=\"ancestor=mustafar/parrot\") 2>/dev/null && docker rm $(docker ps -a -q --filter=\"ancestor=mustafar/parrot\") 2>/dev/null"
   },
   "keywords": [
     "docker",
@@ -41,7 +40,6 @@
     "eslint": "^8.16.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.26.0",
-    "husky": "^8.0.1",
     "jest": "^28.1.0",
     "node-fetch": "^2.0.0"
   },


### PR DESCRIPTION
husky was interfering with the build process by expecting a `.git` folder in `dist`. so removing it, and will lint manually until fixed.

bug report: https://github.com/typicode/husky/issues/851

