### PR TITLE
feat: ignore query hash option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .eslintcache
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ To enable verbose logging, set `VERBOSE` environment variable when running the c
 -e VERBOSE=on
 ```
 
+To ignore the query string when finding a mock, set the `IGNORE_QUERY_HASH` environment variable to `true` when running the container
+```
+-e IGNORE_QUERY_HASH=true
+```
+
 Check out the [tests](https://github.com/mustafar/parrot/blob/master/__tests__/tests.js) for more examples!
 
 # Contributing

--- a/__tests__/setup.sh
+++ b/__tests__/setup.sh
@@ -29,4 +29,15 @@ docker run -d --name parrot-openapi3 \
 -v "${PARROT_ROOT}/__tests__/openapi3.yml":/spec.yml \
 ${PARROT_NAME}:latest
 
+echo '\nstarting openapi3 ignore query container...'
+docker run -d --name parrot-openapi3-ignore-query \
+-e PORT=15011 \
+-e VERBOSE=on \
+-p 15011:15011 \
+-e API_SPEC="/spec.yml" \
+-e IS_OAS3="true" \
+-e IGNORE_QUERY_HASH=true \
+-v "${PARROT_ROOT}/__tests__/openapi3.yml":/spec.yml \
+${PARROT_NAME}:latest
+
 echo 'containers started!'


### PR DESCRIPTION
@mustafar @chris-smith-zocdoc

Adding the ability to ignore a query hash in a parrot. Specifically, we are using parrot for Salesforce mocks - here among other places https://github.com/Zocdoc/book-online-button-service/pull/992. Salesforce queries normally stick the whole SOQL in the query string, which makes it impossible to match the query string when using the current time (down to the ms). Also, just a generally good feature - it was kinda annoying to set up queries in EDAS as well when we were matching on query string.